### PR TITLE
Use loadtest4j 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.loadtest4j</groupId>
             <artifactId>loadtest4j</artifactId>
-            <version>0.7.0</version>
+            <version>0.8.0</version>
         </dependency>
         <dependency>
             <groupId>io.gatling</groupId>

--- a/src/main/scala/com.github.loadtest4j.drivers.gatling/GatlingResult.scala
+++ b/src/main/scala/com.github.loadtest4j.drivers.gatling/GatlingResult.scala
@@ -1,0 +1,13 @@
+package com.github.loadtest4j.drivers.gatling
+
+import java.util.Optional
+
+import com.github.loadtest4j.loadtest4j.DriverResult
+
+class GatlingResult(ok: Long, ko: Long, reportUrl: String) extends DriverResult {
+  override def getKo: Long = ko
+
+  override def getOk: Long = ok
+
+  override def getReportUrl: Optional[String] = Optional.of(reportUrl)
+}

--- a/src/test/scala/com/github/loadtest4j/drivers/gatling/GatlingTest.scala
+++ b/src/test/scala/com/github/loadtest4j/drivers/gatling/GatlingTest.scala
@@ -50,6 +50,7 @@ class GatlingTest {
     // Then
     assertEquals(0, result.getKo)
     assertGreaterThanOrEqualTo(1, result.getOk)
+    assertStartsWith("file://", result.getReportUrl.get())
     // And
     verifyHttp(httpServer).atLeast(1, method(Method.GET), uri("/"))
   }
@@ -106,6 +107,11 @@ class GatlingTest {
       case Failure(e: LoadTesterException) => assertEquals("No requests were specified for the load test.", e.getMessage)
       case _ => fail("This should not work.")
     }
+  }
+
+  private def assertStartsWith(prefix: String, actual: String): Unit = {
+    val msg = "'%s' did not start with the substring '%s'.".format(actual, prefix)
+    assertTrue(msg, actual.startsWith(prefix))
   }
 
   private def assertGreaterThanOrEqualTo(expected: Long, actual: Long): Unit  ={


### PR DESCRIPTION
Use loadtest4j 0.8.0

This lays foundations for #12 - the user must be told where the report can be found in order for any custom reporting to be useful.