### PR TITLE
Include high-fidelity actual test duration in the result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.loadtest4j</groupId>
             <artifactId>loadtest4j</artifactId>
-            <version>0.8.1</version>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>io.gatling</groupId>

--- a/src/main/scala/com.github.loadtest4j.drivers.gatling/GatlingResult.scala
+++ b/src/main/scala/com.github.loadtest4j.drivers.gatling/GatlingResult.scala
@@ -1,13 +1,16 @@
 package com.github.loadtest4j.drivers.gatling
 
+import java.time.Duration
 import java.util.Optional
 
 import com.github.loadtest4j.loadtest4j.DriverResult
 
-class GatlingResult(ok: Long, ko: Long, reportUrl: String) extends DriverResult {
+class GatlingResult(ok: Long, ko: Long, actualDuration: Duration, reportUrl: String) extends DriverResult {
   override def getKo: Long = ko
 
   override def getOk: Long = ok
 
   override def getReportUrl: Optional[String] = Optional.of(reportUrl)
+
+  override def getActualDuration: Duration = actualDuration
 }

--- a/src/test/scala/com/github/loadtest4j/drivers/gatling/GatlingTest.scala
+++ b/src/test/scala/com/github/loadtest4j/drivers/gatling/GatlingTest.scala
@@ -50,6 +50,7 @@ class GatlingTest {
     // Then
     assertEquals(0, result.getKo)
     assertGreaterThanOrEqualTo(1, result.getOk)
+    assertTrue(result.getActualDuration.toMillis > 0)
     assertStartsWith("file://", result.getReportUrl.get())
     // And
     verifyHttp(httpServer).atLeast(1, method(Method.GET), uri("/"))


### PR DESCRIPTION
Use loadtest4j 0.9.0 to achieve this