### PR TITLE
Make 'usersPerSecond' a mandatory property

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A Gatling driver for loadtest4j.
     loadtest4j.driver = com.github.loadtest4j.drivers.gatling.GatlingFactory
     loadtest4j.driver.duration = 10
     loadtest4j.driver.url = https://example.com
+    loadtest4j.driver.usersPerSecond = 1
     ```
 
 3. **Optional: Add advanced Gatling configuration** in `src/test/resources/gatling.conf`.

--- a/src/main/scala/com/github/loadtest4j/drivers/gatling/GatlingFactory.scala
+++ b/src/main/scala/com/github/loadtest4j/drivers/gatling/GatlingFactory.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 class GatlingFactory extends DriverFactory {
 
   override def getMandatoryProperties: util.Set[String] = {
-    JavaConverters.setAsJavaSet(Set("duration", "url"))
+    JavaConverters.setAsJavaSet(Set("duration", "url", "usersPerSecond"))
   }
 
   /**
@@ -19,15 +19,13 @@ class GatlingFactory extends DriverFactory {
     *
     * - `duration`
     * - `url`
+    * - `usersPerSecond`
     *
-    * Optional properties:
-    *
-    * - `usersPerSecond` (defaults to 1)
     */
   override def create(properties: util.Map[String, String]): Driver = {
     val duration = properties.get("duration").toLong.seconds
     val url = properties.get("url")
-    val usersPerSecond = properties.getOrDefault("usersPerSecond", "1").toInt
+    val usersPerSecond = properties.get("usersPerSecond").toInt
 
     new Gatling(duration, url, usersPerSecond)
   }

--- a/src/test/java/com/github/loadtest4j/drivers/gatling/GatlingFactoryTest.java
+++ b/src/test/java/com/github/loadtest4j/drivers/gatling/GatlingFactoryTest.java
@@ -18,7 +18,7 @@ public class GatlingFactoryTest {
         final Set<String> mandatoryProperties = sut.getMandatoryProperties();
 
         assertThat(mandatoryProperties)
-                .containsExactly("duration", "url");
+                .containsExactly("duration", "url", "usersPerSecond");
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -35,6 +35,7 @@ public class GatlingFactoryTest {
         final Map<String, String> properties = new ConcurrentHashMap<>();
         properties.put("duration", "2");
         properties.put("url", "https://example.com");
+        properties.put("usersPerSecond", "1");
 
         final Driver driver = sut.create(properties);
 


### PR DESCRIPTION
New users are unlikely to discover the optional properties so make them all mandatory instead.